### PR TITLE
Add GitLab integration and move sign-in off landing page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3456}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      GITLAB_CLIENT_ID: ${GITLAB_CLIENT_ID:-}
+      GITLAB_CLIENT_SECRET: ${GITLAB_CLIENT_SECRET:-}
       DEBUG: ${DEBUG:-false}
     volumes:
       - app_data:/app/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
       "version": "1.4.18",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.18.tgz",
       "integrity": "sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.3.5"
@@ -101,14 +100,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-      "peer": true
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -1482,7 +1479,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -2107,7 +2103,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/cookie": "^0.6.0",
         "cookie": "^0.6.0",
@@ -2140,7 +2135,6 @@
       "integrity": "sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -2188,7 +2182,6 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2538,7 +2531,6 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
       "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -2560,7 +2552,6 @@
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -2824,7 +2815,6 @@
       "integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@drizzle-team/brocli": "^0.10.2",
         "@esbuild-kit/esm-loader": "^2.5.5",
@@ -3273,7 +3263,6 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
       "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -3417,7 +3406,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3747,7 +3735,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3774,7 +3761,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
       "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -3900,7 +3886,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -4102,7 +4087,6 @@
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4200,7 +4184,6 @@
       "integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -4450,7 +4433,6 @@
       "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4637,7 +4619,6 @@
       "integrity": "sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.39",
@@ -4747,7 +4728,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -104,10 +104,10 @@ const securityHeaders = async ({ event, resolve }) => {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https:",
-    "connect-src 'self' https://api.github.com https://github.com",
+    "connect-src 'self' https://api.github.com https://github.com https://gitlab.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",
-    "form-action 'self' https://github.com",
+    "form-action 'self' https://github.com https://gitlab.com",
   ].join("; ");
 
   response.headers.set("Content-Security-Policy", csp);

--- a/src/lib/auth/auth.js
+++ b/src/lib/auth/auth.js
@@ -21,6 +21,15 @@ function getAuth() {
           clientSecret: process.env.GITHUB_CLIENT_SECRET,
           scope: ["read:user", "repo"],
         },
+        ...(process.env.GITLAB_CLIENT_ID && process.env.GITLAB_CLIENT_SECRET
+          ? {
+              gitlab: {
+                clientId: process.env.GITLAB_CLIENT_ID,
+                clientSecret: process.env.GITLAB_CLIENT_SECRET,
+                scope: ["read_user", "read_api"],
+              },
+            }
+          : {}),
       },
       session: {
         expiresIn: 60 * 60 * 24 * 7, // 7 days

--- a/src/lib/database/accounts.js
+++ b/src/lib/database/accounts.js
@@ -2,18 +2,49 @@ import { db } from "./drizzle.js";
 import { sql } from "drizzle-orm";
 
 /**
- * Gets the GitHub access token for a user from better-auth's account table.
+ * Gets an access token for a user from better-auth's account table.
  *
  * Raw SQL is used here because the `account` table is managed by better-auth
  * and is not part of our Drizzle schema definitions. Defining a Drizzle table
  * for it would risk schema conflicts when better-auth updates its own tables.
  *
  * @param {string} userId - User ID
+ * @param {string} providerId - Provider ID (e.g., 'github', 'gitlab')
+ * @returns {string|null} Access token or null
+ */
+export function getProviderToken(userId, providerId) {
+  const rows = db.all(
+    sql`SELECT "accessToken" FROM account WHERE "userId" = ${userId} AND "providerId" = ${providerId} LIMIT 1`,
+  );
+  return rows?.[0]?.accessToken || null;
+}
+
+/**
+ * Gets the GitHub access token for a user.
+ * @param {string} userId - User ID
  * @returns {string|null} GitHub access token or null
  */
 export function getGitHubToken(userId) {
+  return getProviderToken(userId, "github");
+}
+
+/**
+ * Gets the GitLab access token for a user.
+ * @param {string} userId - User ID
+ * @returns {string|null} GitLab access token or null
+ */
+export function getGitLabToken(userId) {
+  return getProviderToken(userId, "gitlab");
+}
+
+/**
+ * Gets all linked provider IDs for a user.
+ * @param {string} userId - User ID
+ * @returns {string[]} Array of provider IDs (e.g., ['github', 'gitlab'])
+ */
+export function getLinkedProviders(userId) {
   const rows = db.all(
-    sql`SELECT "accessToken" FROM account WHERE "userId" = ${userId} AND "providerId" = 'github' LIMIT 1`,
+    sql`SELECT "providerId" FROM account WHERE "userId" = ${userId}`,
   );
-  return rows?.[0]?.accessToken || null;
+  return rows?.map((r) => r.providerId) || [];
 }

--- a/src/lib/database/drizzle.js
+++ b/src/lib/database/drizzle.js
@@ -95,6 +95,7 @@ if (!isBuilding) {
 		CREATE TABLE IF NOT EXISTS "repositories" (
 			"id" TEXT PRIMARY KEY NOT NULL,
 			"user_id" TEXT NOT NULL,
+			"provider" TEXT NOT NULL DEFAULT 'github',
 			"github_id" INTEGER NOT NULL,
 			"name" TEXT NOT NULL,
 			"full_name" TEXT NOT NULL,
@@ -119,10 +120,11 @@ if (!isBuilding) {
 			"last_scanned_at" INTEGER NOT NULL
 		);
 
-		CREATE UNIQUE INDEX IF NOT EXISTS "repositories_user_id_github_id_unique" ON "repositories" ("user_id", "github_id");
+		CREATE UNIQUE INDEX IF NOT EXISTS "repositories_user_provider_external_id_unique" ON "repositories" ("user_id", "provider", "github_id");
 		CREATE INDEX IF NOT EXISTS "idx_repositories_user_id" ON "repositories" ("user_id");
 		CREATE INDEX IF NOT EXISTS "idx_repositories_last_commit_date" ON "repositories" ("last_commit_date");
 		CREATE INDEX IF NOT EXISTS "idx_repositories_github_id" ON "repositories" ("github_id");
+		CREATE INDEX IF NOT EXISTS "idx_repositories_provider" ON "repositories" ("provider");
 
 		CREATE TABLE IF NOT EXISTS "scan_history" (
 			"id" TEXT PRIMARY KEY NOT NULL,
@@ -150,6 +152,30 @@ if (!isBuilding) {
     );
   } catch {
     // Column already exists — safe to ignore
+  }
+
+  // Add provider column for existing databases (GitLab integration)
+  try {
+    sqlite.exec(
+      `ALTER TABLE repositories ADD COLUMN "provider" TEXT NOT NULL DEFAULT 'github'`,
+    );
+  } catch {
+    // Column already exists — safe to ignore
+  }
+
+  // Migrate unique index from (user_id, github_id) to (user_id, provider, github_id)
+  try {
+    sqlite.exec(
+      `DROP INDEX IF EXISTS "repositories_user_id_github_id_unique"`,
+    );
+    sqlite.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "repositories_user_provider_external_id_unique" ON "repositories" ("user_id", "provider", "github_id")`,
+    );
+    sqlite.exec(
+      `CREATE INDEX IF NOT EXISTS "idx_repositories_provider" ON "repositories" ("provider")`,
+    );
+  } catch {
+    // Index already migrated — safe to ignore
   }
 
   db = drizzle(sqlite, { schema });

--- a/src/lib/database/repositories.js
+++ b/src/lib/database/repositories.js
@@ -42,9 +42,14 @@ import { debugLog, errorLog } from "../utils/env.js";
  * Upserts repositories for a user
  * @param {string} userId - User ID
  * @param {Repository[]} repositoryList - Array of repository data
+ * @param {string} [provider='github'] - Provider name ('github' or 'gitlab')
  * @returns {Promise<Repository[]>} Upserted repositories
  */
-export async function upsertRepositories(userId, repositoryList) {
+export async function upsertRepositories(
+  userId,
+  repositoryList,
+  provider = "github",
+) {
   try {
     if (repositoryList.length === 0) {
       return [];
@@ -52,6 +57,7 @@ export async function upsertRepositories(userId, repositoryList) {
 
     const values = repositoryList.map((repo) => ({
       userId,
+      provider,
       githubId: repo.github_id,
       name: repo.name,
       fullName: repo.full_name,
@@ -78,7 +84,11 @@ export async function upsertRepositories(userId, repositoryList) {
       .insert(repositories)
       .values(values)
       .onConflictDoUpdate({
-        target: [repositories.userId, repositories.githubId],
+        target: [
+          repositories.userId,
+          repositories.provider,
+          repositories.githubId,
+        ],
         set: {
           name: sql`excluded.name`,
           fullName: sql`excluded.full_name`,
@@ -209,23 +219,33 @@ export async function getPublicDashboardData(
 }
 
 /**
- * Deletes repositories that are no longer in the user's GitHub account
+ * Deletes repositories that are no longer in the user's account for a given provider
  * @param {string} userId - User ID
- * @param {number[]} currentGithubIds - Array of current GitHub repo IDs
+ * @param {number[]} currentExternalIds - Array of current external repo IDs
+ * @param {string} [provider='github'] - Provider name ('github' or 'gitlab')
  * @returns {Promise<number>} Number of repositories deleted
  */
-export async function cleanupRemovedRepositories(userId, currentGithubIds) {
+export async function cleanupRemovedRepositories(
+  userId,
+  currentExternalIds,
+  provider = "github",
+) {
   try {
-    if (currentGithubIds.length === 0) {
+    if (currentExternalIds.length === 0) {
       const result = await db
         .delete(repositories)
-        .where(eq(repositories.userId, userId))
+        .where(
+          and(
+            eq(repositories.userId, userId),
+            eq(repositories.provider, provider),
+          ),
+        )
         .returning({ id: repositories.id });
 
       const deletedCount = result.length;
       if (deletedCount > 0) {
         debugLog(
-          `Cleaned up ${deletedCount} removed repositories for user ${userId}`,
+          `Cleaned up ${deletedCount} removed ${provider} repositories for user ${userId}`,
         );
       }
 
@@ -237,7 +257,8 @@ export async function cleanupRemovedRepositories(userId, currentGithubIds) {
       .where(
         and(
           eq(repositories.userId, userId),
-          notInArray(repositories.githubId, currentGithubIds),
+          eq(repositories.provider, provider),
+          notInArray(repositories.githubId, currentExternalIds),
         ),
       )
       .returning({ id: repositories.id });
@@ -245,7 +266,7 @@ export async function cleanupRemovedRepositories(userId, currentGithubIds) {
     const deletedCount = result.length;
     if (deletedCount > 0) {
       debugLog(
-        `Cleaned up ${deletedCount} removed repositories for user ${userId}`,
+        `Cleaned up ${deletedCount} removed ${provider} repositories for user ${userId}`,
       );
     }
 

--- a/src/lib/database/schema.js
+++ b/src/lib/database/schema.js
@@ -120,6 +120,7 @@ export const repositories = sqliteTable(
       .primaryKey()
       .$defaultFn(() => crypto.randomUUID()),
     userId: text("user_id").notNull(),
+    provider: text("provider").default("github").notNull(),
     githubId: integer("github_id").notNull(),
     name: text("name").notNull(),
     fullName: text("full_name").notNull(),
@@ -155,15 +156,15 @@ export const repositories = sqliteTable(
   },
   (table) => {
     return {
-      userGithubUnique: uniqueIndex("repositories_user_id_github_id_unique").on(
-        table.userId,
-        table.githubId,
-      ),
+      userProviderExternalUnique: uniqueIndex(
+        "repositories_user_provider_external_id_unique",
+      ).on(table.userId, table.provider, table.githubId),
       userIdIdx: index("idx_repositories_user_id").on(table.userId),
       lastCommitDateIdx: index("idx_repositories_last_commit_date").on(
         table.lastCommitDate,
       ),
       githubIdIdx: index("idx_repositories_github_id").on(table.githubId),
+      providerIdx: index("idx_repositories_provider").on(table.provider),
     };
   },
 );

--- a/src/lib/database/test-helpers.js
+++ b/src/lib/database/test-helpers.js
@@ -79,6 +79,7 @@ export function createTestDb() {
 		CREATE TABLE IF NOT EXISTS "repositories" (
 			"id" TEXT PRIMARY KEY,
 			"user_id" TEXT NOT NULL,
+			"provider" TEXT NOT NULL DEFAULT 'github',
 			"github_id" INTEGER NOT NULL,
 			"name" TEXT NOT NULL,
 			"full_name" TEXT NOT NULL,
@@ -102,10 +103,11 @@ export function createTestDb() {
 			"updated_at" INTEGER NOT NULL,
 			"last_scanned_at" INTEGER NOT NULL
 		);
-		CREATE UNIQUE INDEX IF NOT EXISTS "repositories_user_id_github_id_unique" ON "repositories" ("user_id", "github_id");
+		CREATE UNIQUE INDEX IF NOT EXISTS "repositories_user_provider_external_id_unique" ON "repositories" ("user_id", "provider", "github_id");
 		CREATE INDEX IF NOT EXISTS "idx_repositories_user_id" ON "repositories" ("user_id");
 		CREATE INDEX IF NOT EXISTS "idx_repositories_last_commit_date" ON "repositories" ("last_commit_date");
 		CREATE INDEX IF NOT EXISTS "idx_repositories_github_id" ON "repositories" ("github_id");
+		CREATE INDEX IF NOT EXISTS "idx_repositories_provider" ON "repositories" ("provider");
 
 		CREATE TABLE IF NOT EXISTS "scan_history" (
 			"id" TEXT PRIMARY KEY,

--- a/src/lib/gitlab/analyzer.js
+++ b/src/lib/gitlab/analyzer.js
@@ -1,0 +1,156 @@
+import { getUserProjects } from "./client.js";
+import { debugLog, errorLog } from "../utils/env.js";
+
+const GITLAB_API_BASE = "https://gitlab.com/api/v4";
+
+/**
+ * Gets the last commit date for a GitLab project
+ * @param {string} accessToken - GitLab access token
+ * @param {number} projectId - GitLab project ID
+ * @param {string} defaultBranch - Default branch name
+ * @returns {Promise<string|null>} Last commit date or null
+ */
+async function getLastCommitDate(accessToken, projectId, defaultBranch) {
+  try {
+    const url = new URL(
+      `${GITLAB_API_BASE}/projects/${projectId}/repository/commits`,
+    );
+    url.searchParams.set("ref_name", defaultBranch);
+    url.searchParams.set("per_page", "1");
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        debugLog(`No commits found for project ${projectId}`);
+        return null;
+      }
+      return null;
+    }
+
+    const commits = await response.json();
+    if (commits.length > 0) {
+      return commits[0].committed_date;
+    }
+
+    return null;
+  } catch (error) {
+    errorLog(`Error fetching last commit for project ${projectId}`, error);
+    return null;
+  }
+}
+
+/**
+ * Analyzes GitLab projects and adds commit information
+ * @param {string} accessToken - GitLab access token
+ * @param {any[]} projects - Array of GitLab projects
+ * @param {function(number, number): void} [onProgress] - Progress callback
+ * @returns {Promise<any[]>} Analyzed projects with commit data
+ */
+export async function analyzeProjects(accessToken, projects, onProgress) {
+  const analyzed = [];
+
+  debugLog(`Analyzing ${projects.length} GitLab projects for commit data`);
+
+  for (let i = 0; i < projects.length; i++) {
+    const project = projects[i];
+
+    try {
+      const lastCommitDate = project.archived
+        ? null
+        : await getLastCommitDate(
+            accessToken,
+            project.id,
+            project.default_branch || "main",
+          );
+
+      analyzed.push({
+        github_id: project.id,
+        name: project.name,
+        full_name: project.path_with_namespace,
+        description: project.description,
+        private: project.visibility !== "public",
+        html_url: project.web_url,
+        clone_url: project.http_url_to_repo,
+        last_commit_date: lastCommitDate,
+        last_push_date: project.last_activity_at,
+        is_fork: !!project.forked_from_project,
+        is_archived: project.archived || false,
+        default_branch: project.default_branch || "main",
+        language: null,
+        stars_count: project.star_count || 0,
+        forks_count: project.forks_count || 0,
+        open_issues_count: project.open_issues_count || 0,
+        size_kb: Math.round((project.statistics?.repository_size || 0) / 1024),
+      });
+
+      if (onProgress) {
+        onProgress(i + 1, projects.length);
+      }
+    } catch (error) {
+      errorLog(
+        `Error analyzing GitLab project ${project.path_with_namespace}`,
+        error,
+      );
+    }
+  }
+
+  debugLog(
+    `Completed analysis of ${analyzed.length}/${projects.length} GitLab projects`,
+  );
+  return analyzed;
+}
+
+/**
+ * Full GitLab repository scan workflow
+ * @param {string} accessToken - GitLab access token
+ * @param {boolean} includePrivate - Include private projects
+ * @param {function(string, any): void} [onStatus] - Status callback
+ * @param {function(number, number): void} [onProgress] - Progress callback
+ * @returns {Promise<any[]>} Analyzed projects
+ */
+export async function performGitLabScan(
+  accessToken,
+  includePrivate = false,
+  onStatus,
+  onProgress,
+) {
+  try {
+    if (onStatus)
+      onStatus("fetching", {
+        message: "Fetching projects from GitLab...",
+      });
+
+    const projects = await getUserProjects(accessToken, includePrivate);
+
+    if (projects.length === 0) {
+      if (onStatus)
+        onStatus("completed", { message: "No GitLab projects found" });
+      return [];
+    }
+
+    if (onStatus)
+      onStatus("analyzing", {
+        message: `Analyzing ${projects.length} GitLab projects...`,
+        total: projects.length,
+      });
+
+    const analyzed = await analyzeProjects(accessToken, projects, onProgress);
+
+    if (onStatus)
+      onStatus("completed", {
+        message: `Analysis completed for ${analyzed.length} GitLab projects`,
+        total: analyzed.length,
+      });
+
+    return analyzed;
+  } catch (error) {
+    if (onStatus) onStatus("error", { message: error.message });
+    throw error;
+  }
+}

--- a/src/lib/gitlab/client.js
+++ b/src/lib/gitlab/client.js
@@ -1,0 +1,91 @@
+import { appLog } from "$lib/utils/env.js";
+
+const GITLAB_API_BASE = "https://gitlab.com/api/v4";
+
+/**
+ * Makes an authenticated request to the GitLab API
+ * @param {string} accessToken - GitLab access token
+ * @param {string} endpoint - API endpoint path (e.g., "/user")
+ * @param {Record<string, string>} [params] - Query parameters
+ * @returns {Promise<any>} Parsed JSON response
+ */
+async function gitlabRequest(accessToken, endpoint, params = {}) {
+  const url = new URL(`${GITLAB_API_BASE}${endpoint}`);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `GitLab API error ${response.status}: ${response.statusText} - ${body}`,
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetches authenticated user information from GitLab
+ * @param {string} accessToken - GitLab access token
+ * @returns {Promise<any>} User information
+ */
+export async function getUserInfo(accessToken) {
+  return gitlabRequest(accessToken, "/user");
+}
+
+/**
+ * Fetches user's owned projects from GitLab
+ * @param {string} accessToken - GitLab access token
+ * @param {boolean} includePrivate - Whether to include private projects
+ * @returns {Promise<any[]>} Array of GitLab projects
+ */
+export async function getUserProjects(accessToken, includePrivate = false) {
+  const projects = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const params = {
+      owned: "true",
+      per_page: String(perPage),
+      page: String(page),
+      order_by: "updated_at",
+      sort: "desc",
+    };
+
+    if (!includePrivate) {
+      params.visibility = "public";
+    }
+
+    const data = await gitlabRequest(accessToken, "/projects", params);
+
+    if (data.length === 0) break;
+    projects.push(...data);
+    if (data.length < perPage) break;
+    page++;
+  }
+
+  return projects;
+}
+
+/**
+ * Tests GitLab API connection
+ * @param {string} accessToken - GitLab access token
+ * @returns {Promise<{user: any}>} User info
+ */
+export async function testConnection(accessToken) {
+  try {
+    const user = await getUserInfo(accessToken);
+    return { user };
+  } catch (error) {
+    throw new Error(`GitLab API connection failed: ${error.message}`);
+  }
+}

--- a/src/lib/jobs/repoRefresh.js
+++ b/src/lib/jobs/repoRefresh.js
@@ -1,5 +1,8 @@
 import { sqlite } from "../database/drizzle.js";
-import { getGitHubToken } from "../database/accounts.js";
+import {
+  getGitHubToken,
+  getGitLabToken,
+} from "../database/accounts.js";
 import { getUserConfig } from "../database/userConfig.js";
 import {
   startScan,
@@ -12,6 +15,7 @@ import {
   cleanupRemovedRepositories,
 } from "../database/repositories.js";
 import { performRepositoryScan } from "../github/analyzer.js";
+import { performGitLabScan } from "../gitlab/analyzer.js";
 import { debugLog, errorLog, appLog } from "../utils/env.js";
 
 /** @type {number} Refresh interval in milliseconds (default 24 hours) */
@@ -40,7 +44,7 @@ let timeoutId = null;
  *
  * Instead of scanning every user at once, it spreads users across the entire
  * refresh interval. If the interval is 24 hours and there are 100 users, one
- * user is scanned roughly every 14 minutes. This prevents GitHub API bursts and
+ * user is scanned roughly every 14 minutes. This prevents API bursts and
  * distributes load evenly.
  *
  * Calling this multiple times is safe -- subsequent calls are no-ops.
@@ -72,7 +76,7 @@ export function stopRepoRefreshJob() {
 }
 
 /**
- * Runs one full refresh cycle: queries all users with linked GitHub accounts,
+ * Runs one full refresh cycle: queries all users with linked accounts,
  * then processes them one at a time with a calculated delay between each user.
  *
  * After the cycle finishes (or if there are no users), it schedules the next
@@ -84,15 +88,13 @@ async function runRefreshCycle() {
   const cycleStart = Date.now();
 
   try {
-    // Query all users with a linked GitHub account from better-auth tables.
-    // Uses the raw sqlite instance because these tables are managed by
-    // better-auth, not by the Drizzle schema (same pattern as accounts.js).
+    // Query all users with a linked account (GitHub or GitLab) from better-auth tables.
     const users = sqlite
       .prepare(
         `SELECT DISTINCT u.id, u.name
 				 FROM "user" u
 				 INNER JOIN "account" a ON u.id = a."userId"
-				 WHERE a."providerId" = 'github'`,
+				 WHERE a."providerId" IN ('github', 'gitlab')`,
       )
       .all();
 
@@ -105,8 +107,6 @@ async function runRefreshCycle() {
     }
 
     // Calculate delay between users to spread them across the full interval.
-    // e.g., 24 hours / 100 users = ~14.4 minutes per user.
-    // Never go below MIN_DELAY_BETWEEN_USERS_MS to avoid hammering the API.
     const delayBetweenUsers = Math.max(
       MIN_DELAY_BETWEEN_USERS_MS,
       Math.floor(REFRESH_INTERVAL_MS / users.length),
@@ -165,7 +165,41 @@ function scheduleNextCycle() {
 }
 
 /**
- * Refreshes repository data for a single user.
+ * Scans a single provider for a user and upserts results.
+ * @param {'github'|'gitlab'} provider
+ * @param {string} userId
+ * @param {string} username
+ * @param {boolean} includePrivate
+ * @param {string} accessToken
+ * @returns {Promise<{scanned: number, upserted: number, deleted: number}>}
+ */
+async function refreshProvider(
+  provider,
+  userId,
+  username,
+  includePrivate,
+  accessToken,
+) {
+  let repos;
+  if (provider === "github") {
+    repos = await performRepositoryScan(accessToken, username, includePrivate);
+  } else {
+    repos = await performGitLabScan(accessToken, includePrivate);
+  }
+
+  if (repos.length === 0) {
+    return { scanned: 0, upserted: 0, deleted: 0 };
+  }
+
+  const currentIds = repos.map((r) => r.github_id);
+  const upserted = await upsertRepositories(userId, repos, provider);
+  const deleted = await cleanupRemovedRepositories(userId, currentIds, provider);
+
+  return { scanned: repos.length, upserted: upserted.length, deleted };
+}
+
+/**
+ * Refreshes repository data for a single user across all linked providers.
  * Skips the user if they were scanned recently (within STALE_THRESHOLD_MS).
  *
  * @param {{ id: string, name: string }} user - User record
@@ -195,14 +229,15 @@ async function refreshUserRepos(user) {
     }
   }
 
-  // Get the GitHub access token (synchronous — uses raw sqlite)
-  const accessToken = getGitHubToken(user.id);
-  if (!accessToken) {
+  // Get tokens for all linked providers
+  const githubToken = getGitHubToken(user.id);
+  const gitlabToken = getGitLabToken(user.id);
+
+  if (!githubToken && !gitlabToken) {
     debugLog(`Repository refresh job: skipping ${user.name} (no token)`);
     return;
   }
 
-  // Reuse config from the auto-refresh check above for scanPrivateRepos preference
   const includePrivate = config?.scanPrivateRepos || false;
 
   appLog("JOB", "Refreshing repos for user " + user.id);
@@ -212,47 +247,47 @@ async function refreshUserRepos(user) {
   const scan = await startScan(user.id);
 
   try {
-    // Perform the same scan as the manual /scan endpoint:
-    // performRepositoryScan(accessToken, username, includePrivate)
-    const repositories = await performRepositoryScan(
-      accessToken,
-      user.name,
-      includePrivate,
-    );
+    let totalScanned = 0;
+    let totalUpserted = 0;
+    let totalDeleted = 0;
 
-    if (repositories.length === 0) {
-      await completeScan(scan.id, {
-        reposScanned: 0,
-        reposAdded: 0,
-        reposUpdated: 0,
-      });
-      debugLog(`Repository refresh job: ${user.name} done — 0 repos found`);
-      return;
+    if (githubToken) {
+      const gh = await refreshProvider(
+        "github",
+        user.id,
+        user.name,
+        includePrivate,
+        githubToken,
+      );
+      totalScanned += gh.scanned;
+      totalUpserted += gh.upserted;
+      totalDeleted += gh.deleted;
     }
 
-    // Get current GitHub IDs for cleanup
-    const currentGithubIds = repositories.map((repo) => repo.github_id);
-
-    // Upsert repositories to database
-    const upsertedRepos = await upsertRepositories(user.id, repositories);
-
-    // Clean up repositories that no longer exist on GitHub
-    const deletedCount = await cleanupRemovedRepositories(
-      user.id,
-      currentGithubIds,
-    );
+    if (gitlabToken) {
+      const gl = await refreshProvider(
+        "gitlab",
+        user.id,
+        user.name,
+        includePrivate,
+        gitlabToken,
+      );
+      totalScanned += gl.scanned;
+      totalUpserted += gl.upserted;
+      totalDeleted += gl.deleted;
+    }
 
     // Complete the scan
     await completeScan(scan.id, {
-      reposScanned: repositories.length,
-      reposAdded: upsertedRepos.length,
-      reposUpdated: upsertedRepos.length,
+      reposScanned: totalScanned,
+      reposAdded: totalUpserted,
+      reposUpdated: totalUpserted,
     });
 
     debugLog(`Repository refresh job: ${user.name} done`, {
-      scanned: repositories.length,
-      upserted: upsertedRepos.length,
-      deleted: deletedCount,
+      scanned: totalScanned,
+      upserted: totalUpserted,
+      deleted: totalDeleted,
     });
   } catch (err) {
     await failScan(scan.id, err);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,32 +1,16 @@
 <script>
 	import { page } from '$app/stores';
-	import { authClient } from '$lib/auth/auth-client.js';
 	import { badges } from '$lib/utils/badges.js';
 
 	$: session = $page.data?.session;
 	$: user = session?.user;
-
-	let isLoading = false;
-
-	async function signInWithGitHub() {
-		isLoading = true;
-		try {
-			await authClient.signIn.social({
-				provider: 'github',
-				callbackURL: '/dashboard',
-			});
-		} catch (err) {
-			console.error('Sign in failed:', err);
-			isLoading = false;
-		}
-	}
 
 	const featuredBadges = badges.slice(0, 6);
 </script>
 
 <svelte:head>
 	<title>Abandoned by Me - A Cemetery for Your Forgotten Code</title>
-	<meta name="description" content="Proudly display your abandoned GitHub repositories. Get sarcastic badges, share your graveyard of unfinished projects, and embrace the art of not finishing things." />
+	<meta name="description" content="Proudly display your abandoned GitHub and GitLab repositories. Get sarcastic badges, share your graveyard of unfinished projects, and embrace the art of not finishing things." />
 </svelte:head>
 
 <div class="landing">
@@ -42,7 +26,7 @@
 			<h1>A Cemetery for Code<br />That Never Made It</h1>
 			<p class="hero-subtitle">
 				Your projects didn't die. They just... stopped living.
-				<br />Scan your GitHub repos, earn sarcastic badges, and share your graveyard with the world.
+				<br />Scan your GitHub &amp; GitLab repos, earn sarcastic badges, and share your graveyard with the world.
 			</p>
 
 			{#if user}
@@ -50,16 +34,9 @@
 					Go to Your Dashboard
 				</a>
 			{:else}
-				<button class="btn-primary" on:click={signInWithGitHub} disabled={isLoading}>
-					{#if isLoading}
-						Redirecting to GitHub...
-					{:else}
-						<svg class="github-icon" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
-							<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-						</svg>
-						Sign in with GitHub
-					{/if}
-				</button>
+				<a href="/login" class="btn-primary">
+					Get Started
+				</a>
 			{/if}
 		</div>
 	</section>
@@ -71,8 +48,8 @@
 			<div class="steps">
 				<div class="step">
 					<div class="step-icon">1</div>
-					<h3>Sign in with GitHub</h3>
-					<p>Connect your account. We only read your public repo data.</p>
+					<h3>Connect Your Account</h3>
+					<p>Sign in with GitHub or GitLab. We only read your public repo data.</p>
 				</div>
 				<div class="step">
 					<div class="step-icon">2</div>
@@ -113,7 +90,7 @@
 				<div class="feature">
 					<span class="feature-icon">🔒</span>
 					<h3>Privacy First</h3>
-					<p>No analytics, no tracking, no telemetry. Your abandoned projects are between you and GitHub.</p>
+					<p>No analytics, no tracking, no telemetry. Your abandoned projects are your business.</p>
 				</div>
 				<div class="feature">
 					<span class="feature-icon">🔗</span>
@@ -142,12 +119,7 @@
 			{#if user}
 				<a href="/dashboard" class="btn-primary">Go to Dashboard</a>
 			{:else}
-				<button class="btn-primary" on:click={signInWithGitHub} disabled={isLoading}>
-					<svg class="github-icon" viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
-						<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-					</svg>
-					Sign in with GitHub
-				</button>
+				<a href="/login" class="btn-primary">Get Started</a>
 			{/if}
 		</div>
 	</section>
@@ -237,17 +209,6 @@
 		transform: translateY(-2px);
 		text-decoration: none;
 		color: white;
-	}
-
-	.btn-primary:disabled {
-		opacity: 0.7;
-		cursor: not-allowed;
-		transform: none;
-	}
-
-	.github-icon {
-		width: 20px;
-		height: 20px;
 	}
 
 	/* How it Works */

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,10 +1,11 @@
 <script>
 	import { authClient } from '$lib/auth/auth-client.js';
 
-	let isLoading = false;
+	let githubLoading = false;
+	let gitlabLoading = false;
 
 	async function signInWithGitHub() {
-		isLoading = true;
+		githubLoading = true;
 		try {
 			await authClient.signIn.social({
 				provider: 'github',
@@ -12,14 +13,27 @@
 			});
 		} catch (err) {
 			console.error('Sign in failed:', err);
-			isLoading = false;
+			githubLoading = false;
+		}
+	}
+
+	async function signInWithGitLab() {
+		gitlabLoading = true;
+		try {
+			await authClient.signIn.social({
+				provider: 'gitlab',
+				callbackURL: '/dashboard',
+			});
+		} catch (err) {
+			console.error('Sign in failed:', err);
+			gitlabLoading = false;
 		}
 	}
 </script>
 
 <svelte:head>
-	<title>Login - Abandoned by Me</title>
-	<meta name="description" content="Sign in to track your abandoned GitHub repositories" />
+	<title>Sign In - Abandoned by Me</title>
+	<meta name="description" content="Sign in to track your abandoned repositories" />
 </svelte:head>
 
 <div class="login-page">
@@ -27,33 +41,55 @@
 		<div class="login-icon">🪦</div>
 		<h1>Ready to Face Your Abandoned Projects?</h1>
 		<p class="subtitle">
-			Sign in with GitHub and we'll show you which repos you've been ghosting.
+			Sign in with your preferred platform and we'll show you which repos you've been ghosting.
 		</p>
 
-		<button
-			on:click={signInWithGitHub}
-			disabled={isLoading}
-			class="github-btn"
-		>
-			{#if isLoading}
-				<div class="loading-spinner"></div>
-				Redirecting to GitHub...
-			{:else}
-				<svg class="github-icon" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-				</svg>
-				Sign in with GitHub
-			{/if}
-		</button>
+		<div class="auth-buttons">
+			<button
+				on:click={signInWithGitHub}
+				disabled={githubLoading || gitlabLoading}
+				class="auth-btn github-btn"
+			>
+				{#if githubLoading}
+					<div class="loading-spinner"></div>
+					Redirecting to GitHub...
+				{:else}
+					<svg class="provider-icon" viewBox="0 0 24 24" fill="currentColor">
+						<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+					</svg>
+					Sign in with GitHub
+				{/if}
+			</button>
+
+			<button
+				on:click={signInWithGitLab}
+				disabled={githubLoading || gitlabLoading}
+				class="auth-btn gitlab-btn"
+			>
+				{#if gitlabLoading}
+					<div class="loading-spinner"></div>
+					Redirecting to GitLab...
+				{:else}
+					<svg class="provider-icon" viewBox="0 0 24 24" fill="currentColor">
+						<path d="M23.955 13.587l-1.342-4.135-2.664-8.189a.455.455 0 00-.867 0L16.418 9.45H7.582L4.918 1.263a.455.455 0 00-.867 0L1.386 9.45.044 13.587a.924.924 0 00.331 1.023L12 23.054l11.625-8.443a.92.92 0 00.33-1.024"/>
+					</svg>
+					Sign in with GitLab
+				{/if}
+			</button>
+		</div>
+
+		<div class="divider">
+			<span>or connect both for a complete graveyard</span>
+		</div>
 
 		<div class="info-cards">
 			<div class="info-card">
 				<span class="info-icon">🔍</span>
-				<p>We'll scan your public GitHub repos to find your abandoned projects</p>
+				<p>We'll scan your public repos to find your abandoned projects</p>
 			</div>
 			<div class="info-card">
 				<span class="info-icon">🔒</span>
-				<p>We only read your public repository data. No write access, ever.</p>
+				<p>We only read your repository data. No write access, ever.</p>
 			</div>
 			<div class="info-card">
 				<span class="info-icon">🚫</span>
@@ -96,13 +132,17 @@
 		margin-bottom: 2rem;
 	}
 
-	.github-btn {
+	.auth-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.auth-btn {
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		gap: 0.75rem;
-		background: var(--color-text-primary);
-		color: var(--color-bg-dark);
 		border: none;
 		padding: 0.85rem 2rem;
 		border-radius: 8px;
@@ -113,18 +153,28 @@
 		width: 100%;
 	}
 
-	.github-btn:hover:not(:disabled) {
+	.auth-btn:hover:not(:disabled) {
 		opacity: 0.9;
 		transform: translateY(-1px);
 	}
 
-	.github-btn:disabled {
+	.auth-btn:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
 		transform: none;
 	}
 
-	.github-icon {
+	.github-btn {
+		background: var(--color-text-primary);
+		color: var(--color-bg-dark);
+	}
+
+	.gitlab-btn {
+		background: #fc6d26;
+		color: white;
+	}
+
+	.provider-icon {
 		width: 22px;
 		height: 22px;
 	}
@@ -143,8 +193,28 @@
 		100% { transform: rotate(360deg); }
 	}
 
+	.divider {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin: 1.5rem 0;
+	}
+
+	.divider::before,
+	.divider::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: var(--color-border);
+	}
+
+	.divider span {
+		font-size: 0.8rem;
+		color: var(--color-text-muted);
+		white-space: nowrap;
+	}
+
 	.info-cards {
-		margin-top: 2.5rem;
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;

--- a/src/routes/scan/+server.js
+++ b/src/routes/scan/+server.js
@@ -14,7 +14,11 @@ import {
   getRunningScan,
 } from "$lib/database/scanHistory.js";
 import { performRepositoryScan } from "$lib/github/analyzer.js";
-import { getGitHubToken } from "$lib/database/accounts.js";
+import { performGitLabScan } from "$lib/gitlab/analyzer.js";
+import {
+  getGitHubToken,
+  getGitLabToken,
+} from "$lib/database/accounts.js";
 import { errorLog, debugLog, appLog } from "$lib/utils/env.js";
 import { scanLimiter, getClientKey } from "$lib/utils/rateLimit.js";
 
@@ -60,24 +64,31 @@ export async function POST(event) {
     // Get user configuration
     const config = await getUserConfig(userId);
 
-    // Get the GitHub access token from the account linked via better-auth
-    // Validate token BEFORE creating a scan record to avoid orphaned "running" records
-    const accessToken = getGitHubToken(userId);
+    // Check which providers are linked
+    const githubToken = getGitHubToken(userId);
+    const gitlabToken = getGitLabToken(userId);
 
-    if (!accessToken) {
+    if (!githubToken && !gitlabToken) {
       throw error(
         400,
-        "GitHub account not linked. Please sign in with GitHub again.",
+        "No accounts linked. Please sign in with GitHub or GitLab.",
       );
     }
 
-    // Start scan record (only after token is confirmed valid)
+    // Start scan record (only after at least one token is confirmed valid)
     const scan = await startScan(userId);
     appLog("SCAN", "Scan started for user " + userId);
     debugLog(`Started repository scan for user ${username}`);
 
     // Perform the scan asynchronously (don't await)
-    performScanAsync(scan.id, userId, username, config, accessToken);
+    performScanAsync(
+      scan.id,
+      userId,
+      username,
+      config,
+      githubToken,
+      gitlabToken,
+    );
 
     return json({
       success: true,
@@ -128,55 +139,121 @@ export async function GET({ url, request }) {
 }
 
 /**
- * Performs the repository scan asynchronously
+ * Performs the repository scan asynchronously across all linked providers
  */
-async function performScanAsync(scanId, userId, username, config, accessToken) {
+async function performScanAsync(
+  scanId,
+  userId,
+  username,
+  config,
+  githubToken,
+  gitlabToken,
+) {
   try {
     debugLog(`Performing async scan ${scanId} for user ${username}`);
 
-    // Perform the GitHub repository scan
-    const repositories = await performRepositoryScan(
-      accessToken,
-      username,
-      config.scanPrivateRepos,
-    );
+    let totalScanned = 0;
+    let totalUpserted = 0;
+    let totalDeleted = 0;
 
-    if (repositories.length === 0) {
-      await completeScan(scanId, {
-        reposScanned: 0,
-        reposAdded: 0,
-        reposUpdated: 0,
-      });
-      return;
+    // Scan GitHub repos if linked
+    if (githubToken) {
+      const ghResult = await scanProvider(
+        "github",
+        userId,
+        username,
+        config,
+        githubToken,
+      );
+      totalScanned += ghResult.scanned;
+      totalUpserted += ghResult.upserted;
+      totalDeleted += ghResult.deleted;
     }
 
-    // Get current GitHub IDs for cleanup
-    const currentGithubIds = repositories.map((repo) => repo.github_id);
-
-    // Upsert repositories to database
-    const upsertedRepos = await upsertRepositories(userId, repositories);
-
-    // Clean up repositories that no longer exist on GitHub
-    const deletedCount = await cleanupRemovedRepositories(
-      userId,
-      currentGithubIds,
-    );
+    // Scan GitLab repos if linked
+    if (gitlabToken) {
+      const glResult = await scanProvider(
+        "gitlab",
+        userId,
+        username,
+        config,
+        gitlabToken,
+      );
+      totalScanned += glResult.scanned;
+      totalUpserted += glResult.upserted;
+      totalDeleted += glResult.deleted;
+    }
 
     // Complete the scan
     await completeScan(scanId, {
-      reposScanned: repositories.length,
-      reposAdded: upsertedRepos.length,
-      reposUpdated: upsertedRepos.length,
+      reposScanned: totalScanned,
+      reposAdded: totalUpserted,
+      reposUpdated: totalUpserted,
     });
 
     appLog("SCAN", "Scan completed for user " + userId);
     debugLog(`Completed scan ${scanId}`, {
-      scanned: repositories.length,
-      upserted: upsertedRepos.length,
-      deleted: deletedCount,
+      scanned: totalScanned,
+      upserted: totalUpserted,
+      deleted: totalDeleted,
     });
   } catch (scanError) {
     errorLog(`Scan ${scanId} failed`, scanError);
     await failScan(scanId, scanError);
   }
+}
+
+/**
+ * Scans a single provider's repositories
+ * @param {'github'|'gitlab'} provider
+ * @param {string} userId
+ * @param {string} username
+ * @param {any} config
+ * @param {string} accessToken
+ * @returns {Promise<{scanned: number, upserted: number, deleted: number}>}
+ */
+async function scanProvider(provider, userId, username, config, accessToken) {
+  debugLog(`Scanning ${provider} repositories for ${username}`);
+
+  let repositories;
+
+  if (provider === "github") {
+    repositories = await performRepositoryScan(
+      accessToken,
+      username,
+      config.scanPrivateRepos,
+    );
+  } else {
+    repositories = await performGitLabScan(
+      accessToken,
+      config.scanPrivateRepos,
+    );
+  }
+
+  if (repositories.length === 0) {
+    return { scanned: 0, upserted: 0, deleted: 0 };
+  }
+
+  // Get current external IDs for cleanup
+  const currentExternalIds = repositories.map((repo) => repo.github_id);
+
+  // Upsert repositories to database
+  const upsertedRepos = await upsertRepositories(
+    userId,
+    repositories,
+    provider,
+  );
+
+  // Clean up repositories that no longer exist on the provider
+  const deletedCount = await cleanupRemovedRepositories(
+    userId,
+    currentExternalIds,
+    provider,
+  );
+
+  return {
+    scanned: repositories.length,
+    upserted: upsertedRepos.length,
+    deleted: deletedCount,
+  };
 }


### PR DESCRIPTION
- Add GitLab as a second OAuth provider via better-auth (conditional on
  GITLAB_CLIENT_ID/GITLAB_CLIENT_SECRET env vars being set)
- Create GitLab API client and repository analyzer that mirrors the
  existing GitHub integration
- Add `provider` column to repositories table with migration support
  for existing databases (defaults to 'github')
- Update scan endpoint and background refresh job to scan both GitHub
  and GitLab repos when accounts are linked
- Refactor accounts.js with generic getProviderToken() plus
  getLinkedProviders() helpers
- Make repository upsert and cleanup provider-scoped to prevent
  cross-provider interference
- Replace sign-in buttons on landing page with "Get Started" links
  to /login for a cleaner design
- Add GitHub and GitLab sign-in buttons side by side on login page
  with GitLab's brand color (#fc6d26)
- Update CSP headers and docker-compose for GitLab API domain
- Update test helpers and verify all 110 unit tests pass

https://claude.ai/code/session_01JK8AkffLkzsuusubKVyv2M