### PR TITLE
Fix security vulnerabilities and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ The SQLite database is created automatically on first run. No external services 
 
 ## Environment Variables
 
-| Variable               | Description                    | Default                 |
-| ---------------------- | ------------------------------ | ----------------------- |
-| `DATABASE_URL`         | SQLite file path               | `./data/app.db`         |
-| `GITHUB_CLIENT_ID`     | GitHub OAuth App client ID     | —                       |
-| `GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret | —                       |
-| `BETTER_AUTH_SECRET`   | Secret for auth encryption     | —                       |
-| `BETTER_AUTH_URL`      | App URL for auth callbacks     | `http://localhost:5173` |
-| `REFRESH_INTERVAL_HOURS` | Auto-refresh interval        | `24`                    |
-| `DEBUG`                | Enable debug logging           | `false`                 |
+| Variable                 | Description                    | Default                 |
+| ------------------------ | ------------------------------ | ----------------------- |
+| `DATABASE_URL`           | SQLite file path               | `./data/app.db`         |
+| `GITHUB_CLIENT_ID`       | GitHub OAuth App client ID     | —                       |
+| `GITHUB_CLIENT_SECRET`   | GitHub OAuth App client secret | —                       |
+| `BETTER_AUTH_SECRET`     | Secret for auth encryption     | —                       |
+| `BETTER_AUTH_URL`        | App URL for auth callbacks     | `http://localhost:5173` |
+| `REFRESH_INTERVAL_HOURS` | Auto-refresh interval          | `24`                    |
+| `DEBUG`                  | Enable debug logging           | `false`                 |
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,33 @@
 # Abandoned by Me
 
-Track your abandoned GitHub repositories. Sign in with GitHub, scan your repos, and see which ones you've forgotten about. Share a public dashboard so others can see your graveyard of side projects.
+A cemetery for code that never made it. Sign in with GitHub, scan your repos, and face the truth about your abandoned side projects. Share your graveyard with the world so others can pay their respects.
 
-## Quick Start
+**Live at [abandoned-by-me.dev](https://abandoned-by-me.dev)**
+
+## Features
+
+- **Repository scanning** — Connects to GitHub, analyzes commit history, and identifies which repos you've abandoned (configurable threshold)
+- **Badges of Dishonor** — Earn achievements like "Serial Abandoner", "Graveyard Keeper", and "January Enthusiast" based on your repo patterns
+- **Public dashboards** — Shareable profile pages showing your abandoned repos (public repos only)
+- **Pay Respects** — Visitors can anonymously pay respects to your fallen projects
+- **Repo Adoption Agency** — Mark abandoned repos as "up for adoption" so other developers can discover and fork them
+- **Auto-refresh** — Optional background job keeps your graveyard up to date
+- **Privacy-first** — No analytics, no tracking, no telemetry. Delete your account and all data at any time
+
+## Tech Stack
+
+- [SvelteKit](https://kit.svelte.dev/) — Full-stack framework
+- [SQLite](https://sqlite.org/) via [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) — Database
+- [Drizzle ORM](https://orm.drizzle.team/) — Type-safe database queries
+- [better-auth](https://www.better-auth.com/) — Authentication (GitHub OAuth)
+- [Octokit](https://github.com/octokit/octokit.js) — GitHub API client
+
+## Local Development
 
 1. **Create a GitHub OAuth App** at [github.com/settings/developers](https://github.com/settings/developers)
 
-   - Set the homepage URL to `http://localhost:5173`
-   - Set the callback URL to `http://localhost:5173/api/auth/callback/github`
+   - Homepage URL: `http://localhost:5173`
+   - Callback URL: `http://localhost:5173/api/auth/callback/github`
 
 2. **Set up the project**
 
@@ -23,13 +43,30 @@ Track your abandoned GitHub repositories. Sign in with GitHub, scan your repos, 
 
 The SQLite database is created automatically on first run. No external services needed.
 
-## Tech Stack
+## Environment Variables
 
-- [SvelteKit](https://kit.svelte.dev/) — Full-stack framework
-- [SQLite](https://sqlite.org/) via [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) — Database
-- [Drizzle ORM](https://orm.drizzle.team/) — Type-safe database queries
-- [better-auth](https://www.better-auth.com/) — Authentication (GitHub OAuth)
-- [Octokit](https://github.com/octokit/octokit.js) — GitHub API client
+| Variable               | Description                    | Default                 |
+| ---------------------- | ------------------------------ | ----------------------- |
+| `DATABASE_URL`         | SQLite file path               | `./data/app.db`         |
+| `GITHUB_CLIENT_ID`     | GitHub OAuth App client ID     | —                       |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret | —                       |
+| `BETTER_AUTH_SECRET`   | Secret for auth encryption     | —                       |
+| `BETTER_AUTH_URL`      | App URL for auth callbacks     | `http://localhost:5173` |
+| `REFRESH_INTERVAL_HOURS` | Auto-refresh interval        | `24`                    |
+| `DEBUG`                | Enable debug logging           | `false`                 |
+
+## Commands
+
+```bash
+npm run dev          # Start dev server
+npm run build        # Production build
+npm run preview      # Preview production build
+npm run test         # Run all tests (integration + unit)
+npm run test:unit    # Unit tests (Vitest)
+npm run format       # Format with Prettier
+npm run lint         # Run ESLint
+npm run db:studio    # Browse database with Drizzle Studio
+```
 
 ## Docker Deployment
 
@@ -42,28 +79,6 @@ docker-compose -f docker-compose.dev.yml up
 ```
 
 SQLite data is persisted via a Docker volume. Set environment variables in your `.env` file or deployment platform (e.g., Dokploy).
-
-## Environment Variables
-
-| Variable               | Description                    | Default                 |
-| ---------------------- | ------------------------------ | ----------------------- |
-| `DATABASE_URL`         | SQLite file path               | `./data/app.db`         |
-| `GITHUB_CLIENT_ID`     | GitHub OAuth App client ID     | —                       |
-| `GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret | —                       |
-| `BETTER_AUTH_SECRET`   | Secret for auth encryption     | —                       |
-| `BETTER_AUTH_URL`      | App URL for auth callbacks     | `http://localhost:5173` |
-| `DEBUG`                | Enable debug logging           | `false`                 |
-
-## Development
-
-```bash
-npm run dev          # Start dev server
-npm run build        # Production build
-npm run test         # Run all tests
-npm run test:unit    # Unit tests (Vitest)
-npm run format       # Format with Prettier
-npm run db:studio    # Browse database with Drizzle Studio
-```
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       "devDependencies": {
         "@fontsource/fira-mono": "^4.5.10",
         "@neoconfetti/svelte": "^1.0.0",
-        "@playwright/test": "^1.28.1",
+        "@playwright/test": "^1.55.1",
         "@sveltejs/adapter-node": "^2.0.0",
-        "@sveltejs/kit": "^2.0.0",
+        "@sveltejs/kit": "^2.20.6",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
         "@types/better-sqlite3": "^7.6.13",
         "drizzle-kit": "^0.31.8",
@@ -27,7 +27,7 @@
         "prettier": "^3.1.1",
         "prettier-plugin-svelte": "^3.1.2",
         "svelte": "^4.2.7",
-        "vite": "^5.0.3",
+        "vite": "^5.4.21",
         "vitest": "^3.2.4"
       }
     },
@@ -1497,16 +1497,31 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.0.0",
+        "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@octokit/graphql": {
@@ -1591,18 +1606,33 @@
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.3.tgz",
-      "integrity": "sha512-o4WRoOJZlKqEEgj+i9CpcmnByvtzoUYC6I8PD2SA95M+BJ2x8h7oLcVOg9qcowWXBOdcTRsMZiwvM3EyLm9AfA==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.5.0"
+        "@octokit/types": "^13.10.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -1654,14 +1684,15 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
-      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^10.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.1.0",
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -1669,15 +1700,45 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
-      "integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.0.0"
+        "@octokit/types": "^14.0.0"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -1713,13 +1774,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.2.tgz",
-      "integrity": "sha512-JxG9eq92ET75EbVi3s+4sYbcG7q72ECeZNbdBlaMkGcNbiDQ4cAi8U2QP5oKkOx+1gpaiL1LDStmzCaEM1Z6fQ==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.45.2"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1729,9 +1790,9 @@
       }
     },
     "node_modules/@polka/url": {
-      "version": "1.0.0-next.25",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
-      "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -1855,9 +1916,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.1.tgz",
-      "integrity": "sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
       "cpu": [
         "arm"
       ],
@@ -1869,9 +1930,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.1.tgz",
-      "integrity": "sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
       "cpu": [
         "arm64"
       ],
@@ -1883,9 +1944,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.1.tgz",
-      "integrity": "sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
       "cpu": [
         "arm64"
       ],
@@ -1897,9 +1958,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.1.tgz",
-      "integrity": "sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
       "cpu": [
         "x64"
       ],
@@ -1910,10 +1971,38 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.1.tgz",
-      "integrity": "sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
       "cpu": [
         "arm"
       ],
@@ -1925,9 +2014,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.1.tgz",
-      "integrity": "sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
       "cpu": [
         "arm"
       ],
@@ -1939,9 +2028,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.1.tgz",
-      "integrity": "sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
       "cpu": [
         "arm64"
       ],
@@ -1953,9 +2042,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.1.tgz",
-      "integrity": "sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1966,10 +2055,52 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.1.tgz",
-      "integrity": "sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
       "cpu": [
         "ppc64"
       ],
@@ -1981,9 +2112,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.1.tgz",
-      "integrity": "sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
       "cpu": [
         "riscv64"
       ],
@@ -1995,9 +2140,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.1.tgz",
-      "integrity": "sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
       "cpu": [
         "s390x"
       ],
@@ -2009,9 +2154,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.1.tgz",
-      "integrity": "sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
       "cpu": [
         "x64"
       ],
@@ -2023,9 +2168,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.1.tgz",
-      "integrity": "sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
       "cpu": [
         "x64"
       ],
@@ -2036,10 +2181,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.1.tgz",
-      "integrity": "sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2051,9 +2224,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.1.tgz",
-      "integrity": "sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
       "cpu": [
         "ia32"
       ],
@@ -2064,10 +2237,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz",
-      "integrity": "sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
       "cpu": [
         "x64"
       ],
@@ -2083,6 +2270,16 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
+      "integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
     },
     "node_modules/@sveltejs/adapter-node": {
       "version": "2.1.2",
@@ -2101,26 +2298,26 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.5.18",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.18.tgz",
-      "integrity": "sha512-+g06hvpVAnH7b4CDjhnTDgFWBKBiQJpuSmQeGYOuzbO3SC3tdYjRNlDCrafvDtKbGiT2uxY5Dn9qdEUGVZdWOQ==",
+      "version": "2.50.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.50.2.tgz",
+      "integrity": "sha512-875hTUkEbz+MyJIxWbQjfMaekqdmEKUUfR7JyKcpfMRZqcGyrO9Gd+iS1D/Dx8LpE5FEtutWGOtlAh4ReSAiOA==",
       "devOptional": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/cookie": "^0.6.0",
+        "acorn": "^8.14.1",
         "cookie": "^0.6.0",
-        "devalue": "^5.0.0",
-        "esm-env": "^1.0.0",
-        "import-meta-resolve": "^4.1.0",
+        "devalue": "^5.6.2",
+        "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
         "mrmime": "^2.0.0",
         "sade": "^1.8.1",
-        "set-cookie-parser": "^2.6.0",
-        "sirv": "^2.0.4",
-        "tiny-glob": "^0.2.9"
+        "set-cookie-parser": "^3.0.0",
+        "sirv": "^3.0.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -2129,15 +2326,32 @@
         "node": ">=18.13"
       },
       "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^3.0.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "vite": "^5.0.3"
+        "typescript": "^5.3.3",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
+    "node_modules/@sveltejs/kit/node_modules/set-cookie-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
+      "integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.1.tgz",
-      "integrity": "sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+      "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -2219,9 +2433,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -2358,11 +2572,12 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2812,16 +3027,16 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.0.0.tgz",
-      "integrity": "sha512-gO+/OMXF7488D+u3ue+G7Y4AA3ZmUnB3eHJXmBTgNHvr4ZNzl36A0ZtG+XCRNYCkYx/bFmw4qtkoFLa+wSrwAA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/drizzle-kit": {
-      "version": "0.31.8",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.8.tgz",
-      "integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
+      "version": "0.31.9",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.9.tgz",
+      "integrity": "sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -3464,9 +3679,9 @@
       }
     },
     "node_modules/esm-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
-      "integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -3498,6 +3713,22 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3627,20 +3858,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globalyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3673,17 +3890,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-      "devOptional": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -3854,9 +4060,9 @@
       }
     },
     "node_modules/mrmime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -3871,9 +4077,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "devOptional": true,
       "funding": [
         {
@@ -3990,9 +4196,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "devOptional": true,
       "license": "ISC"
     },
@@ -4010,13 +4216,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.2.tgz",
-      "integrity": "sha512-ReywF2t/0teRvNBpfIgh5e4wnrI/8Su8ssdo5XsQKpjxJj+jspm00jSoz9BTg91TT0c9HRjXO7LBNVrgYj9X0g==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.45.2"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4029,9 +4235,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.2.tgz",
-      "integrity": "sha512-ha175tAWb0dTK0X4orvBIqi3jGEt701SMxMhyujxNrgd8K0Uy5wMSwwcQHtyB4om7INUkfndx02XnQ2p6dvLDw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4042,9 +4248,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "devOptional": true,
       "funding": [
         {
@@ -4062,9 +4268,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4195,14 +4401,14 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
-      "integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4212,22 +4418,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.1",
-        "@rollup/rollup-android-arm64": "4.18.1",
-        "@rollup/rollup-darwin-arm64": "4.18.1",
-        "@rollup/rollup-darwin-x64": "4.18.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.1",
-        "@rollup/rollup-linux-arm64-musl": "4.18.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.1",
-        "@rollup/rollup-linux-x64-gnu": "4.18.1",
-        "@rollup/rollup-linux-x64-musl": "4.18.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.1",
-        "@rollup/rollup-win32-x64-msvc": "4.18.1",
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -4341,9 +4556,9 @@
       }
     },
     "node_modules/sirv": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4352,7 +4567,7 @@
         "totalist": "^3.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/source-map": {
@@ -4366,9 +4581,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4445,9 +4660,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
-      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
+      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -4510,17 +4725,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tiny-glob": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
       }
     },
     "node_modules/tinybench": {
@@ -4632,16 +4836,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.4.tgz",
-      "integrity": "sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
-        "rollup": "^4.13.0"
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4660,6 +4864,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -4675,6 +4880,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "devDependencies": {
     "@fontsource/fira-mono": "^4.5.10",
     "@neoconfetti/svelte": "^1.0.0",
-    "@playwright/test": "^1.28.1",
+    "@playwright/test": "^1.55.1",
     "@sveltejs/adapter-node": "^2.0.0",
-    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/kit": "^2.20.6",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "drizzle-kit": "^0.31.8",
@@ -40,7 +40,7 @@
     "prettier": "^3.1.1",
     "prettier-plugin-svelte": "^3.1.2",
     "svelte": "^4.2.7",
-    "vite": "^5.0.3",
+    "vite": "^5.4.21",
     "vitest": "^3.2.4"
   }
 }

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -2,10 +2,16 @@ import { sequence } from "@sveltejs/kit/hooks";
 import { building } from "$app/environment";
 import { startRepoRefreshJob } from "$lib/jobs/repoRefresh.js";
 import { error } from "@sveltejs/kit";
-import { accessLog } from "$lib/utils/env.js";
+import { accessLog, validateEnvironment } from "$lib/utils/env.js";
 
-// Start background jobs once on server startup (not during build)
+// Validate required environment variables on startup (not during build)
 if (!building) {
+  validateEnvironment([
+    "BETTER_AUTH_SECRET",
+    "BETTER_AUTH_URL",
+    "GITHUB_CLIENT_ID",
+    "GITHUB_CLIENT_SECRET",
+  ]);
   startRepoRefreshJob();
 }
 
@@ -60,20 +66,21 @@ const csrfProtection = async ({ event, resolve }) => {
 
     // Allow requests from better-auth's internal flows (they set correct origin)
     // and from same-origin. Block requests with missing or mismatched origin.
-    if (origin) {
-      let originHost;
-      try {
-        originHost = new URL(origin).host;
-      } catch {
-        throw error(403, "Forbidden");
-      }
-      if (originHost !== host) {
-        throw error(403, "Forbidden");
-      }
+    if (!origin) {
+      // Modern browsers always send Origin on non-safe requests.
+      // Reject requests without Origin to prevent CSRF attacks.
+      throw error(403, "Forbidden");
     }
-    // If no Origin header is present, the request likely comes from a non-browser
-    // client (e.g., curl, server-to-server). We allow these through since they
-    // can't carry cookies/sessions from a victim's browser (CSRF requires a browser).
+
+    let originHost;
+    try {
+      originHost = new URL(origin).host;
+    } catch {
+      throw error(403, "Forbidden");
+    }
+    if (originHost !== host) {
+      throw error(403, "Forbidden");
+    }
   }
 
   return resolve(event);
@@ -97,20 +104,8 @@ const securityHeaders = async ({ event, resolve }) => {
   // Remove server identification
   response.headers.set("X-Powered-By", "");
 
-  // CSP for security while allowing necessary resources
-  const csp = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' https://fonts.gstatic.com",
-    "img-src 'self' data: https:",
-    "connect-src 'self' https://api.github.com https://github.com",
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-    "form-action 'self' https://github.com",
-  ].join("; ");
-
-  response.headers.set("Content-Security-Policy", csp);
+  // CSP is configured in svelte.config.js using SvelteKit's built-in CSP
+  // with automatic nonce generation (no unsafe-inline for scripts).
 
   return response;
 };

--- a/src/lib/jobs/repoRefresh.js
+++ b/src/lib/jobs/repoRefresh.js
@@ -1,4 +1,5 @@
-import { sqlite } from "../database/drizzle.js";
+import { db, sqlite } from "../database/drizzle.js";
+import { sql } from "drizzle-orm";
 import { getGitHubToken } from "../database/accounts.js";
 import { getUserConfig } from "../database/userConfig.js";
 import {
@@ -85,16 +86,15 @@ async function runRefreshCycle() {
 
   try {
     // Query all users with a linked GitHub account from better-auth tables.
-    // Uses the raw sqlite instance because these tables are managed by
-    // better-auth, not by the Drizzle schema (same pattern as accounts.js).
-    const users = sqlite
-      .prepare(
-        `SELECT DISTINCT u.id, u.name
-				 FROM "user" u
-				 INNER JOIN "account" a ON u.id = a."userId"
-				 WHERE a."providerId" = 'github'`,
-      )
-      .all();
+    // Uses Drizzle's sql template tag for parameterization safety, even though
+    // this query has no user input. These tables are managed by better-auth,
+    // not by our Drizzle schema.
+    const users = db.all(
+      sql`SELECT DISTINCT u.id, u.name
+          FROM "user" u
+          INNER JOIN "account" a ON u.id = a."userId"
+          WHERE a."providerId" = 'github'`,
+    );
 
     appLog("JOB", "Repo refresh started");
 

--- a/src/lib/utils/session.js
+++ b/src/lib/utils/session.js
@@ -1,0 +1,26 @@
+import { error } from "@sveltejs/kit";
+import { auth } from "$lib/auth/auth.js";
+
+/**
+ * Validates an authenticated session from request headers.
+ * Checks both that the session exists and that it has not expired.
+ *
+ * @param {Headers} headers - Request headers
+ * @returns {Promise<{ user: { id: string, name: string, email: string }, session: object }>}
+ * @throws {import('@sveltejs/kit').HttpError} 401 if not authenticated or session expired
+ */
+export async function requireSession(headers) {
+  const session = await auth.api.getSession({ headers });
+  if (!session?.user) {
+    throw error(401, "Authentication required");
+  }
+
+  if (
+    session.session?.expiresAt &&
+    new Date(session.session.expiresAt) < new Date()
+  ) {
+    throw error(401, "Session expired. Please sign in again.");
+  }
+
+  return session;
+}

--- a/src/routes/api/account/+server.js
+++ b/src/routes/api/account/+server.js
@@ -1,5 +1,5 @@
 import { error, json } from "@sveltejs/kit";
-import { auth } from "$lib/auth/auth.js";
+import { requireSession } from "$lib/utils/session.js";
 import { db, sqlite } from "$lib/database/drizzle.js";
 import {
   scanHistory,
@@ -17,18 +17,7 @@ import { accountDeleteLimiter, getClientKey } from "$lib/utils/rateLimit.js";
 export async function DELETE(event) {
   try {
     const { request } = event;
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session?.user) {
-      throw error(401, "Authentication required");
-    }
-
-    // Validate session has not expired before irreversible action
-    if (
-      session.session?.expiresAt &&
-      new Date(session.session.expiresAt) < new Date()
-    ) {
-      throw error(401, "Session expired. Please sign in again.");
-    }
+    const session = await requireSession(request.headers);
 
     // Rate limit account deletion attempts per IP
     const rateCheck = accountDeleteLimiter.check(getClientKey(event));

--- a/src/routes/api/config/+server.js
+++ b/src/routes/api/config/+server.js
@@ -1,5 +1,5 @@
 import { error, json } from "@sveltejs/kit";
-import { auth } from "$lib/auth/auth.js";
+import { requireSession } from "$lib/utils/session.js";
 import {
   getUserConfig,
   updateUserConfig,
@@ -14,10 +14,7 @@ import { configLimiter } from "$lib/utils/rateLimit.js";
  */
 export async function GET({ request }) {
   try {
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session?.user) {
-      throw error(401, "Authentication required");
-    }
+    const session = await requireSession(request.headers);
 
     const config = await getUserConfig(session.user.id);
     return json(config);
@@ -33,18 +30,7 @@ export async function GET({ request }) {
  */
 export async function POST({ request }) {
   try {
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session?.user) {
-      throw error(401, "Authentication required");
-    }
-
-    // Validate session has not expired
-    if (
-      session.session?.expiresAt &&
-      new Date(session.session.expiresAt) < new Date()
-    ) {
-      throw error(401, "Session expired. Please sign in again.");
-    }
+    const session = await requireSession(request.headers);
 
     // Rate limit config updates per user
     const rateCheck = configLimiter.check(session.user.id);

--- a/src/routes/api/public/[slug]/+server.js
+++ b/src/routes/api/public/[slug]/+server.js
@@ -32,7 +32,7 @@ export async function GET({ params }) {
         dashboardSlug: dashboardData.config.dashboardSlug,
       },
       user: {
-        id: dashboardData.user.id,
+        name: dashboardData.user.name,
       },
       stats: {
         total: publicRepositories.length,

--- a/src/routes/api/repos/[id]/adoption/+server.js
+++ b/src/routes/api/repos/[id]/adoption/+server.js
@@ -1,5 +1,5 @@
 import { error, json } from "@sveltejs/kit";
-import { auth } from "$lib/auth/auth.js";
+import { requireSession } from "$lib/utils/session.js";
 import { db, repositories } from "$lib/database/drizzle.js";
 import { eq, and } from "drizzle-orm";
 import { adoptionLimiter } from "$lib/utils/rateLimit.js";
@@ -8,10 +8,7 @@ import { adoptionLimiter } from "$lib/utils/rateLimit.js";
  * Toggle up_for_adoption status on a repository (auth required, must own repo)
  */
 export async function POST({ params, request }) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) {
-    throw error(401, "Authentication required");
-  }
+  const session = await requireSession(request.headers);
 
   // Rate limit adoption toggles per user
   const rateCheck = adoptionLimiter.check(session.user.id);

--- a/src/routes/api/repos/[id]/respect/+server.js
+++ b/src/routes/api/repos/[id]/respect/+server.js
@@ -43,6 +43,7 @@ export async function POST(event) {
     maxAge: 60 * 60 * 24,
     httpOnly: true,
     sameSite: "lax",
+    secure: true,
   });
 
   return json({ respectsCount: result[0].respectsCount });

--- a/src/routes/api/repositories/+server.js
+++ b/src/routes/api/repositories/+server.js
@@ -1,5 +1,5 @@
 import { error, json } from "@sveltejs/kit";
-import { auth } from "$lib/auth/auth.js";
+import { requireSession } from "$lib/utils/session.js";
 import {
   getUserRepositories,
   getAbandonedRepositories,
@@ -12,11 +12,7 @@ import { errorLog } from "$lib/utils/env.js";
  */
 export async function GET({ url, request }) {
   try {
-    // Check authentication via better-auth
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session?.user) {
-      throw error(401, "Authentication required");
-    }
+    const session = await requireSession(request.headers);
 
     const userId = session.user.id;
 

--- a/src/routes/scan/+server.js
+++ b/src/routes/scan/+server.js
@@ -1,6 +1,6 @@
 import { error, json } from "@sveltejs/kit";
 import { eq, and } from "drizzle-orm";
-import { auth } from "$lib/auth/auth.js";
+import { requireSession } from "$lib/utils/session.js";
 import { db, scanHistory } from "$lib/database/drizzle.js";
 import { getUserConfig } from "$lib/database/userConfig.js";
 import {
@@ -24,10 +24,7 @@ import { scanLimiter, getClientKey } from "$lib/utils/rateLimit.js";
 export async function POST(event) {
   try {
     const { request } = event;
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session?.user) {
-      throw error(401, "Authentication required");
-    }
+    const session = await requireSession(request.headers);
 
     // Rate limit scan requests per user
     const rateCheck = scanLimiter.check(session.user.id);
@@ -101,11 +98,7 @@ export async function GET({ url, request }) {
       throw error(400, "Scan ID required");
     }
 
-    const session = await auth.api.getSession({ headers: request.headers });
-    if (!session?.user) {
-      throw error(401, "Authentication required");
-    }
-
+    const session = await requireSession(request.headers);
     const userId = session.user.id;
 
     // Get scan status

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,10 +3,20 @@ import adapter from "@sveltejs/adapter-node";
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-    // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-    // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
+    csp: {
+      directives: {
+        "default-src": ["self"],
+        "script-src": ["self"],
+        "style-src": ["self", "unsafe-inline", "https://fonts.googleapis.com"],
+        "font-src": ["self", "https://fonts.gstatic.com"],
+        "img-src": ["self", "data:", "https:"],
+        "connect-src": ["self", "https://api.github.com", "https://github.com"],
+        "frame-ancestors": ["none"],
+        "base-uri": ["self"],
+        "form-action": ["self", "https://github.com"],
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

- **Dependency upgrades**: Bump `vite` (5.4.21), `@sveltejs/kit` (2.20.6), `@playwright/test` (1.55.1) to resolve 18 open Dependabot alerts including XSS, `server.fs.deny` bypasses, and SSL certificate verification issues
- **Security hardening**: Remove `unsafe-inline` from CSP `script-src` (moved to SvelteKit's built-in nonce-based CSP), require `Origin` header on state-changing requests, add `secure` flag to cookies, centralize session validation across all authenticated endpoints, remove internal user ID from public API, validate env vars on startup
- **README update**: Add live deployment URL (abandoned-by-me.dev), document all current features, update commands and environment variables

## Security fixes

| Issue | Fix |
|-------|-----|
| CSP `unsafe-inline` in `script-src` | Moved to SvelteKit `kit.csp` with automatic nonce generation |
| CSRF allows missing Origin header | Non-safe methods now reject requests without Origin |
| Missing `secure` flag on cookies | Added `secure: true` to respect cookies |
| Inconsistent session expiration checks | Created `requireSession()` helper, applied to all 7 authenticated endpoints |
| Internal user ID exposed in public API | Changed to return `user.name` instead of `user.id` |
| Raw SQL in background job | Refactored to use Drizzle's `sql` template tag |
| No env var validation on startup | Added `validateEnvironment()` call in hooks.server.js |
| Outdated vite/kit/playwright | Bumped minimum versions to resolve Dependabot CVEs |

## Test plan

- [x] All 110 unit tests pass
- [x] Production build succeeds
- [ ] Verify public dashboard still renders correctly (user.name instead of user.id)
- [ ] Verify CSRF protection doesn't block normal browser POST requests
- [ ] Verify CSP nonces work correctly for inline scripts in rendered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)