### PR TITLE
Fix Docker build failure caused by prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "db:push": "drizzle-kit push:sqlite",
     "db:migrate": "node src/lib/database/migrate.js",
     "db:studio": "drizzle-kit studio",
-    "prepare": "simple-git-hooks"
+    "prepare": "simple-git-hooks || true"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
- The `prepare` script (`simple-git-hooks`) fails during Docker builds when only production dependencies are installed, since `simple-git-hooks` is a devDependency
- Adding `|| true` allows the script to gracefully no-op in environments where the binary isn't available (Docker builds, CI with `--only=production`)
- Fixes the Release workflow failure on `v1.0.1`

## Test plan
- [ ] CI passes on this PR
- [ ] Docker build succeeds (`docker build .`)
- [ ] Pre-commit hook still works locally (`npm install` sets up git hooks)

🤖 Generated with [Claude Code](https://claude.ai/code)