### PR TITLE
Add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Format Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: contents: read` to CI and Release workflows
- Resolves 5 CodeQL `actions/missing-workflow-permissions` alerts
- Follows the principle of least privilege — jobs only get read access by default
- The `build-and-push` job in `release.yml` already overrides with `packages: write` at the job level

## Test plan
- [x] CI passes on this PR
- [x] CodeQL alerts resolve after merge

🤖 Generated with [Claude Code](https://claude.ai/code)