### PR TITLE
Fix Docker log volume permissions and incorrect logging comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,19 +28,25 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-# Don't run production as root
+
+# su-exec for dropping privileges in the entrypoint
+RUN apk add --no-cache su-exec
+
+# Create non-root user
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 sveltekit
 
-# Create data directory for SQLite database
-RUN mkdir -p /app/data && chown sveltekit:nodejs /app/data
+# Create data and logs directories for SQLite database and log files
+RUN mkdir -p /app/data/logs && chown -R sveltekit:nodejs /app/data
 
 # Copy built application
 COPY --from=builder --chown=sveltekit:nodejs /app/build ./build
 COPY --from=builder --chown=sveltekit:nodejs /app/package*.json ./
 COPY --from=deps --chown=sveltekit:nodejs /app/node_modules ./node_modules
 
-USER sveltekit
+# Copy entrypoint script (runs as root to fix permissions, then drops to sveltekit)
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 3456
 
@@ -48,4 +54,5 @@ ENV HOST=0.0.0.0
 ENV PORT=3456
 ENV DATABASE_URL=/app/data/app.db
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["node", "build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       DEBUG: ${DEBUG:-false}
     volumes:
       - app_data:/app/data
-      - ./logs:/app/data/logs
     healthcheck:
       test:
         [

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Ensure data directories exist with correct ownership.
+# This handles existing named volumes that may have stale permissions
+# from earlier image builds (self-healing on container start).
+mkdir -p /app/data/logs
+chown -R sveltekit:nodejs /app/data
+
+# Drop privileges and run the application
+exec su-exec sveltekit "$@"

--- a/src/lib/utils/env.js
+++ b/src/lib/utils/env.js
@@ -17,7 +17,7 @@ try {
  * Creates a pino logger with stdout + daily-rotated file transports.
  *
  * Uses pino-roll for daily file rotation with 5-day retention.
- * Logs are written as human-readable text (not JSON) to both stdout and file.
+ * Logs are written as structured JSON to both stdout and file.
  */
 const logger = pino(
   {


### PR DESCRIPTION
## Summary

- **Fix Docker volume permissions for logs directory (#17)**: Removed the `./logs` bind mount from `docker-compose.yml` that overlaid the `app_data` named volume causing ownership conflicts. Added `/app/data/logs` directory creation in the Dockerfile. Added a `docker-entrypoint.sh` script that ensures correct ownership of `/app/data` at startup via `su-exec`, making the container self-healing for existing deployments with stale volume permissions.
- **Fix incorrect logging format comment (#8)**: Corrected the JSDoc comment in `env.js` that described pino output as "human-readable text (not JSON)" when the logger produces structured JSON.

Closes #8
Closes #17

## Test plan

- [ ] Verify unit tests pass (`npm run test:unit` — 112 tests passing)
- [ ] Build Docker image and confirm `/app/data/logs` directory exists with correct ownership
- [ ] Start container with an existing named volume (stale permissions) and verify the entrypoint self-heals ownership
- [ ] Confirm logs are written successfully inside the container
- [ ] Review `env.js` comment matches actual pino JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)